### PR TITLE
[PROTOCOL] Startup message

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake ];
+                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc ];
+                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/src/connection.sml
+++ b/src/connection.sml
@@ -10,14 +10,6 @@ structure PostgresClient = struct
             socket
         end
 
-    fun read (socket: Socket.active INetSock.stream_sock) =
-        case Socket.select{rds = [Socket.sockDesc socket], wrs=[], exs=[], timeout=SOME(Time.fromSeconds 10)} of
-            { rds = [], ...} => ()
-        |  _ => let val text = Socket.recvVec(socket, 1)
-                in if Word8Vector.length text = 0 then ()
-                        else ( print(Byte.bytesToString text); read socket )
-                end
-
     fun convertString (elem: string) =
         (Word8Vector.fromList (List.map Byte.charToByte (String.explode elem)))
 
@@ -50,24 +42,12 @@ structure PostgresClient = struct
             val protocolVersion = 
                 Word8Vector.fromList [0w0, 0w3, 0w0, 0w0]
             val buffer = Word8VectorSlice.full (Word8Vector.concat [ length, protocolVersion, message ])
-            (* val buffer = Word8VectorSlice.full (Word8Vector.concat [length, protocolVersion, serializedMessage]) *)
-            (* val socket = connect() *)
-            (* val buffer2 =  *)
-                (* Hardcoded but correct startup message *)
-                (* Word8VectorSlice.full *)
-                    (* (Word8Vector.fromList *)
-                        (* [ 0wx00, 0wx00, 0wx00, 0wx24, 0wx00, 0wx03, 0wx00, 0wx00, 0wx75, 0wx73, 0wx65, 0wx72, 0wx00, 0wx61, 0wx64, 0wx6d, 0wx69, 0wx6e, 0wx00, 0wx64, 0wx61, 0wx74, 0wx61, 0wx62, 0wx61, 0wx73, 0wx65, 0wx00, 0wx73, 0wx6f, 0wx63, 0wx6b, 0wx65, 0wx74, 0wx00, 0wx00 ]) *)
             val buf = PolyML.makestring buffer
-            (* val buf2 = PolyML.makestring buffer2 *)
         in 
             print buf;
             print "\n\n";
-            (* print buf2; *)
 
             Socket.sendVec(socket, buffer)
-            (* read socket; *)
-            
-            (* Socket.close socket *)
         end
 
         fun parser (socket: Socket.active INetSock.stream_sock) =

--- a/src/connection.sml
+++ b/src/connection.sml
@@ -19,32 +19,70 @@ structure PostgresClient = struct
                 end
 
     fun convertString (elem: string) =
-        (Word8Vector.fromList (List.rev (List.map Byte.charToByte (String.explode elem))))
+        (Word8Vector.fromList (List.map Byte.charToByte (String.explode elem)))
 
-    fun convertInt (n: int) =
+    fun intToBytes (n: int) =
         Word8Vector.fromList
             [ Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx24)), 0wxFF),
               Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx16)), 0wxFF),
               Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx8)), 0wxFF),
               Word8.andb (Word8.fromInt n, 0wxFF) ]
 
+    fun bytesToInt (bytes: Word8Vector.vector) =
+        let
+            open Word8
+            open Word8VectorSlice
+            val slices = full bytes
+            val first = sub(slices, 0)
+            val second = sub(slices, 1)
+            val third = sub(slices, 2)
+            val fourth = sub(slices, 3)
+        in
+            Word8.toInt (orb (fourth, (orb ((<< (third, 0wx8)), (orb ((<< (second, 0wx16)), (<< (first, 0wx24))))))))
+        end
+
     fun startup (socket: Socket.active INetSock.stream_sock) =
         let 
-            val message = convertString "user\000postgres\000database\000postgres\000postgres\000\000"
+            val message = convertString "user\000admin\000database\000socket\000\000"
             val length = 
-                convertInt 50
+                intToBytes 36
                 (* Word8Vector.fromList [ 0wx50, 0wx0, 0wx0, 0wx0 ] *)
             val protocolVersion = 
                 Word8Vector.fromList [0w0, 0w3, 0w0, 0w0]
             val buffer = Word8VectorSlice.full (Word8Vector.concat [ length, protocolVersion, message ])
             (* val buffer = Word8VectorSlice.full (Word8Vector.concat [length, protocolVersion, serializedMessage]) *)
             (* val socket = connect() *)
-            val buf = PolyML.makestring protocolVersion
+            (* val buffer2 =  *)
+                (* Hardcoded but correct startup message *)
+                (* Word8VectorSlice.full *)
+                    (* (Word8Vector.fromList *)
+                        (* [ 0wx00, 0wx00, 0wx00, 0wx24, 0wx00, 0wx03, 0wx00, 0wx00, 0wx75, 0wx73, 0wx65, 0wx72, 0wx00, 0wx61, 0wx64, 0wx6d, 0wx69, 0wx6e, 0wx00, 0wx64, 0wx61, 0wx74, 0wx61, 0wx62, 0wx61, 0wx73, 0wx65, 0wx00, 0wx73, 0wx6f, 0wx63, 0wx6b, 0wx65, 0wx74, 0wx00, 0wx00 ]) *)
+            val buf = PolyML.makestring buffer
+            (* val buf2 = PolyML.makestring buffer2 *)
         in 
             print buf;
-            Socket.sendVec(socket, buffer);
-            read socket;
+            print "\n\n";
+            (* print buf2; *)
+
+            Socket.sendVec(socket, buffer)
+            (* read socket; *)
             
-            Socket.close socket
+            (* Socket.close socket *)
         end
+
+        fun parser (socket: Socket.active INetSock.stream_sock) =
+            let
+                val messageType = Byte.bytesToString (Socket.recvVec(socket, 1))
+                val length =  
+                    bytesToInt(Socket.recvVec(socket, 4))
+                val mP =  PolyML.makestring messageType
+                val lP =  PolyML.makestring length
+            in 
+                case messageType of
+                    "R" => print "Password"
+                  | "Z" => print "ReadyForQuery"
+                  | "E" => print "Error"
+                  | _ => print "NAY";
+                Socket.close socket
+            end
 end

--- a/src/connection.sml
+++ b/src/connection.sml
@@ -1,4 +1,5 @@
 structure PostgresClient = struct
+
     fun connect () =
         let 
             val socket: Socket.active INetSock.stream_sock = INetSock.TCP.socket()
@@ -17,17 +18,33 @@ structure PostgresClient = struct
                         else ( print(Byte.bytesToString text); read socket )
                 end
 
+    fun convertString (elem: string) =
+        (Word8Vector.fromList (List.rev (List.map Byte.charToByte (String.explode elem))))
+
+    fun convertInt (n: int) =
+        Word8Vector.fromList
+            [ Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx24)), 0wxFF),
+              Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx16)), 0wxFF),
+              Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx8)), 0wxFF),
+              Word8.andb (Word8.fromInt n, 0wxFF) ]
+
     fun startup (socket: Socket.active INetSock.stream_sock) =
         let 
-            val message = "user\\0postgres\\0database\\0postgres\\0postgres\\0\\0"
-            val length = Word8Vector.fromList [ Word8.fromInt (String.size message) ]
-            val protocolVersion = Word8Vector.fromList [Word8.fromInt 196608]
-            val serializedMessage = Byte.stringToBytes message
-            val buffer = Word8VectorSlice.full (Word8Vector.concat [length, protocolVersion, serializedMessage])
+            val message = convertString "user\000postgres\000database\000postgres\000postgres\000\000"
+            val length = 
+                convertInt 50
+                (* Word8Vector.fromList [ 0wx50, 0wx0, 0wx0, 0wx0 ] *)
+            val protocolVersion = 
+                Word8Vector.fromList [0w0, 0w3, 0w0, 0w0]
+            val buffer = Word8VectorSlice.full (Word8Vector.concat [ length, protocolVersion, message ])
+            (* val buffer = Word8VectorSlice.full (Word8Vector.concat [length, protocolVersion, serializedMessage]) *)
             (* val socket = connect() *)
-            val _ = Socket.sendVec(socket, buffer)
-            val () = read socket
+            val buf = PolyML.makestring protocolVersion
         in 
+            print buf;
+            Socket.sendVec(socket, buffer);
+            read socket;
+            
             Socket.close socket
         end
 end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -1,9 +1,7 @@
 fun main _ =
     let 
       val socket = PostgresClient.connect()
-      (* val test = PolyML.makestring (PostgresClient.bytesToInt(PostgresClient.intToBytes(12))) *)
     in
       PostgresClient.startup socket;
       PostgresClient.parser socket
-      (* print test *)
     end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -1,6 +1,9 @@
 fun main _ =
     let 
       val socket = PostgresClient.connect()
+      (* val test = PolyML.makestring (PostgresClient.bytesToInt(PostgresClient.intToBytes(12))) *)
     in
-      PostgresClient.startup socket
+      PostgresClient.startup socket;
+      PostgresClient.parser socket
+      (* print test *)
     end


### PR DESCRIPTION
### Context
To open the communication channel, Postgres requires the conversation to start with a "startup" message.

### Scope
Here I implement:
- Serialization and deserialization for 32-bit integers with bitwise operators;
- A startup function that sends a message in the format: length including self (currently hardcoded at 36, int32) + protocol version (3.0) + a null terminated string with user and database;
- A parser function to handle the response according to the possible message types.

### How to test
- To start postgres:
  - nix develop --impure
  - devenv up 
- To compile and run:
  - nix develop --impure
  - polyc -o main build.sml && ./main

### Notes
Tested on a big endian machine. It might break on a little endian architecture.
Also, I do handle the close currently at the parser function, for the time being I will keep it in there, but the correct approach would probably be closing it on the defined scope outside (main)