### PR TITLE
[PROTOCOL] Authentication, Queries and Results

### DIFF
--- a/build.sml
+++ b/build.sml
@@ -1,5 +1,1 @@
-app use [
-    "src/md5.sml",
-    "src/connection.sml",
-    "tests/main.sml"
-]
+app use ["src/md5.sml", "src/connection.sml", "tests/main.sml"];

--- a/build.sml
+++ b/build.sml
@@ -1,4 +1,5 @@
 app use [
+    "src/md5.sml",
     "src/connection.sml",
     "tests/main.sml"
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -4,9 +4,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "nix": "nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -121,16 +119,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689098530,
-        "narHash": "sha256-fxc/9f20wRyo/5ydkmZkX/Sh/ULa7RcT8h+cUv8p/44=",
-        "owner": "nixos",
+        "lastModified": 1690083312,
+        "narHash": "sha256-I3egwgNXavad1eIjWu1kYyi0u73di/sMmlnQIuzQASk=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2406198ea0e4e37d4380d0e20336c575b8f8ef9",
+        "rev": "af8cd5ded7735ca1df1a1174864daab75feeb64a",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -167,6 +165,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1690031011,
+        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12303c652b881435065a98729eb7278313041e49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": [
@@ -198,7 +212,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.mlton pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
+                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc ];
+                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/flake.nix
+++ b/flake.nix
@@ -1,36 +1,79 @@
 {
-  description = "SMLpg";
-
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    devenv = {
-      url = "github:cachix/devenv";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    devenv.url = "github:cachix/devenv";
   };
 
-  outputs = inputs@{ self, devenv, nixpkgs, ... }:
+  outputs = { self, nixpkgs, devenv, ... } @ inputs:
     let
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
-
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-
-      nixpkgsFor = forAllSystems (system: import nixpkgs {
-        inherit system;
-      });
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
     in
-    {
+      {
+        packages = forAllSystems (system:
+          let
+            pkgs = nixpkgs.legacyPackages."${system}";
+          in {
+            # docs = pkgs.stdenv.mkDerivation {
+            #   name = "docs";
+            #   src = ./.;
+
+            #   installPhase = ''
+            #     mkdir -p $out
+
+            #     # remove first heading
+            #     # sed -i '1d' README.md
+
+            #     # add frontmatter to markdown file, required by hugo
+            #     # sed -i '1s/^/---\ntitle: Railroad\n---\n\n/' README.md
+
+            #     # cp README.md $out/Railroad.md
+            #     # cp -r docs $out/
+            #   '';
+            # };
+          });
+
+      apps = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          poly = "${pkgs.polyml}/bin/polyc";
+          mktemp = "${pkgs.coreutils}/bin/mktemp";
+        in {
+          # test = {
+            # type = "app";
+            # program = toString (pkgs.writeShellScript "run-tests" ''
+              # output=$(${mktemp})
+              # ${mlton} -output $output tests/tests.mlb && $output
+            # '');
+          # };
+
+          build = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "build-program" ''
+              output=$(${mktemp})
+              ${poly} -o $output build.sml && echo "Successfully built!"
+            '');
+          };
+
+          execute = {
+            type = "app";
+            program = toString (pkgs.writeShellScript "execute-program" ''
+              output=$(${mktemp})
+              ${poly} -o $output build.sml && $output
+            '');
+          };
+        });
+
       devShells = forAllSystems (system:
         let
-          pkgs = nixpkgsFor."${system}";
-          inherit (pkgs);
+          pkgs = nixpkgs.legacyPackages.${system};
         in
         {
           default = devenv.lib.mkShell {
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
+                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             inherit inputs pkgs;
             modules = [
               ({ pkgs, lib, ... }: {
-                packages = [ pkgs.millet pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
+                packages = [ pkgs.millet pkgs.mlton pkgs.polyml pkgs.smlfmt pkgs.gnumake pkgs.gcc pkgs.glibc pkgs.libressl ];
 
                 services.postgres = {
                   package = pkgs.postgresql_15.withPackages (p: [ ]);

--- a/smlpg.cm
+++ b/smlpg.cm
@@ -1,4 +1,5 @@
 Group is
+	src/md5.sml
 	src/connection.sml
 	tests/main.sml
 	build.sml

--- a/src/connection.sml
+++ b/src/connection.sml
@@ -1,14 +1,17 @@
 (* https://www.postgresql.org/docs/current/protocol-message-formats.html *)
-signature VENDOR_DRIVER = sig
+signature VENDOR_DRIVER =
+sig
   datatype 't Operation = OK | ERROR of 't
   val connect: unit -> (INetSock.inet, Socket.active Socket.stream) Socket.sock
   val startup: (INetSock.inet, Socket.active Socket.stream) Socket.sock -> int
-  val execute: (INetSock.inet, Socket.active Socket.stream) Socket.sock -> string -> 'a Operation
+  val execute: (INetSock.inet, Socket.active Socket.stream) Socket.sock
+               -> string
+               -> 'a Operation
   val parser: (INetSock.inet, Socket.active Socket.stream) Socket.sock -> unit
   val display: unit -> unit
 end
 
-structure PostgresClient : VENDOR_DRIVER =
+structure PostgresClient: VENDOR_DRIVER =
 struct
 
   datatype 't Operation = OK | ERROR of 't
@@ -167,17 +170,16 @@ struct
             [Word8VectorSlice.subslice (!contents, 0, SOME 4)])
         in
           case size of
-            ~1 => (
-              
-              contents := Word8VectorSlice.subslice (!contents, 4, NONE);
-              { name = (#name elem)
-              , sqlType = (#sqlType elem)
-              , records = "NULL" :: (#records elem)
-              }
-            )
+            ~1 =>
+              (
+                contents := Word8VectorSlice.subslice (!contents, 4, NONE)
+              ; { name = (#name elem)
+                , sqlType = (#sqlType elem)
+                , records = "NULL" :: (#records elem)
+                }
+              )
           | n =>
-              (print ("NULL!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" ^ (Int.toString n) ^ "\n");
-              contents := Word8VectorSlice.subslice (!contents, 4 + n, NONE)
+              ( contents := Word8VectorSlice.subslice (!contents, 4 + n, NONE)
               ; { name = (#name elem)
                 , sqlType = (#sqlType elem)
                 , records =
@@ -187,7 +189,7 @@ struct
                 }
               )
         end
-        (* handle SysErr => (print "Here!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"; elem) *)
+    (* handle SysErr => (print "Here!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n"; elem) *)
     in
       print mP;
       print "\n\n";

--- a/src/connection.sml
+++ b/src/connection.sml
@@ -1,124 +1,194 @@
 (* https://www.postgresql.org/docs/current/protocol-message-formats.html *)
 
-structure PostgresClient = struct
+structure PostgresClient =
+struct
 
-    datatype 't Operation = OK | ERROR of 't
+  datatype 't Operation = OK | ERROR of 't
 
-    fun connect () =
-        let 
-            val socket: Socket.active INetSock.stream_sock = INetSock.TCP.socket()
-            val SOME postgres = NetHostDB.getByName "127.0.0.1"
-            val addr = INetSock.toAddr(NetHostDB.addr postgres, 5432)
-        in
-            Socket.connect (socket, addr);
-            socket
-        end
+  fun connect () =
+    let
+      val socket: Socket.active INetSock.stream_sock = INetSock.TCP.socket ()
+      val SOME postgres = NetHostDB.getByName "127.0.0.1"
+      val addr = INetSock.toAddr (NetHostDB.addr postgres, 5432)
+    in
+      Socket.connect (socket, addr);
+      socket
+    end
 
-    fun convertString (elem: string) =
-        (Word8Vector.fromList (List.map Byte.charToByte (String.explode elem)))
+  fun convertString (elem: string) =
+    (Word8Vector.fromList (List.map Byte.charToByte (String.explode elem)))
 
-    fun intToBytes (n: int) =
-        Word8Vector.fromList
-            [ Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx24)), 0wxFF),
-              Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx16)), 0wxFF),
-              Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx8)), 0wxFF),
-              Word8.andb (Word8.fromInt n, 0wxFF) ]
+  fun intToBytes (n: int) =
+    Word8Vector.fromList
+      [ Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx24)), 0wxFF)
+      , Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx16)), 0wxFF)
+      , Word8.andb ((Word8.>> ((Word8.fromInt n), 0wx8)), 0wxFF)
+      , Word8.andb (Word8.fromInt n, 0wxFF)
+      ]
 
-    fun bytesToInt (bytes: Word8Vector.vector) =
-        let
-            open Word8
-            open Word8VectorSlice
-            val slices = full bytes
-            val first = sub(slices, 0)
-            val second = sub(slices, 1)
-            val third = sub(slices, 2)
-            val fourth = sub(slices, 3)
-        in
-            Word8.toInt (orb (fourth, (orb ((<< (third, 0wx8)), (orb ((<< (second, 0wx16)), (<< (first, 0wx24))))))))
-        end
+  fun bytesToInt (bytes: Word8Vector.vector) =
+    let
+      open Word8
+      open Word8VectorSlice
+      val slices = full bytes
+      val first = sub (slices, 0)
+      val second = sub (slices, 1)
+      val third = sub (slices, 2)
+      val fourth = sub (slices, 3)
+    in
+      Word8.toInt (orb (fourth, (orb ((<<(third, 0wx8)), (orb
+        ((<<(second, 0wx16)), (<<(first, 0wx24))))))))
+    end
 
-    fun startup (socket: Socket.active INetSock.stream_sock) =
-        let 
-            val message = convertString "user\000admin\000database\000socket\000\000"
-            val length = 
-                intToBytes 36
-                (* Word8Vector.fromList [ 0wx50, 0wx0, 0wx0, 0wx0 ] *)
-            val protocolVersion = 
-                Word8Vector.fromList [0w0, 0w3, 0w0, 0w0]
-            val buffer = Word8VectorSlice.full (Word8Vector.concat [ length, protocolVersion, message ])
-            val buf = PolyML.makestring buffer
-        in 
-            print buf;
-            print "\n\n";
+  fun bytesToInt16 (bytes: Word8Vector.vector) =
+    let
+      open Word8
+      open Word8VectorSlice
+      val slices = full bytes
+      val first = sub (slices, 0)
+      val second = sub (slices, 1)
+    in
+      Word8.toInt (orb (second, (<<(first, 0wx8))))
+    end
 
-            Socket.sendVec(socket, buffer)
-        end
+  fun startup (socket: Socket.active INetSock.stream_sock) =
+    let
+      val message = convertString "user\000admin\000database\000socket\000\000"
+      val length = intToBytes 36
+      (* Word8Vector.fromList [ 0wx50, 0wx0, 0wx0, 0wx0 ] *)
+      val protocolVersion = Word8Vector.fromList [0w0, 0w3, 0w0, 0w0]
+      val buffer = Word8VectorSlice.full
+        (Word8Vector.concat [length, protocolVersion, message])
+    (* val buf = PolyML.makestring buffer *)
+    in
+      (* print buf; *)
+      (* print "\n\n"; *)
 
-        fun password (message: Word8Vector.vector) =
-            
-            let 
-                val (vec, _, _) = Word8VectorSlice.base (Word8VectorSlice.slice (message, 0, SOME 4))
-            in 
-                case (bytesToInt vec) of
-                  0 => OK
-                | 5 => ERROR "MD5 method not implemented."
-                | _ => ERROR "Unindentified password method."
-            end
-            
-            (* let 
-                val inner = 
-                    MD5.final (MD5.update(MD5.init, convertString "admin\000admin"))
-                val pwd =
-                    Word8Vector.concat
-                        [(convertString "md5"),
-                         (MD5.final (MD5.update (MD5.init, (Word8Vector.concat [ inner, convertString salt ]))))]
-                val serialized = PolyML.makestring pwd
-            in 
-                print serialized
-            end *)
+      Socket.sendVec (socket, buffer)
+    end
 
-        fun execute (socket: Socket.active INetSock.stream_sock) query =
-            let 
-                val queryFlag = 
-                    Word8VectorSlice.full (Word8Vector.fromList [Byte.charToByte #"Q"])
-                val serializedQuery = 
-                    Word8VectorSlice.full (convertString query)
-                val length = intToBytes (1 + 4 + Word8VectorSlice.length serializedQuery)
-                val message = Word8VectorSlice.full (Word8VectorSlice.concat [queryFlag, Word8VectorSlice.full length, serializedQuery])
-                val str = PolyML.makestring message
-            in  print str;
-                Socket.sendVec (socket, message);
-                OK
-            end 
+  fun password (message: Word8Vector.vector) =
 
-        fun parser (socket: Socket.active INetSock.stream_sock) =
-            let
-                val messageType = 
-                    Byte.bytesToString (Socket.recvVec(socket, 1))
-                val length =  
-                    bytesToInt(Socket.recvVec(socket, 4))
-                val message = Socket.recvVec(socket, length - 5)
-                val mP =  "Type: " ^ PolyML.makestring messageType
-                val lP = PolyML.makestring length
-                val messagePrint = PolyML.makestring message
-                val pwd = convertString "admin"
-                val x = Word8VectorSlice.full (Word8Vector.concat [Word8Vector.fromList [Byte.charToByte #"p"], intToBytes (Word8Vector.length pwd + 1 + 4), pwd])
-            in 
-                print "\n\n";
-                print messagePrint;
-                print "\n\n";
-                print mP;
-                print "\n\n";
-                case messageType of
-                    "R" =>
-                    (print "Authenticating";
-                     password (Socket.recvVec(socket, length)))
-                  | _ => 
-                    (print "Ready for query";
-                     execute socket "SELECT 'Hello :)'")
-                  (* | "E" => ERROR "Error" *)
-                  (* | "p" => (Socket.sendVec(socket, x); ERROR "Password response") *)
-                  (* | "\^V" => (print lP; OK) *)
-                  (* | _ => ERROR "NAY" *)
-            end
+    let
+      val (vec, _, _) = Word8VectorSlice.base
+        (Word8VectorSlice.slice (message, 0, SOME 4))
+    in
+      case (bytesToInt vec) of
+        0 => OK
+      | 5 => ERROR "MD5 method not implemented."
+      | _ => ERROR "Unindentified password method."
+    end
+
+  (* let 
+      val inner = 
+          MD5.final (MD5.update(MD5.init, convertString "admin\000admin"))
+      val pwd =
+          Word8Vector.concat
+              [(convertString "md5"),
+               (MD5.final (MD5.update (MD5.init, (Word8Vector.concat [ inner, convertString salt ]))))]
+      val serialized = PolyML.makestring pwd
+  in 
+      print serialized
+  end *)
+
+  fun execute (socket: Socket.active INetSock.stream_sock) query =
+    let
+      val queryFlag = Word8VectorSlice.full
+        (Word8Vector.fromList [Byte.charToByte #"Q"])
+      val serializedQuery = Word8VectorSlice.full (convertString query)
+      val length = intToBytes (4 + 1 + Word8VectorSlice.length serializedQuery)
+      val message = Word8VectorSlice.full (Word8VectorSlice.concat
+        [ queryFlag
+        , Word8VectorSlice.full length
+        , serializedQuery
+        , Word8VectorSlice.full (convertString "\000")
+        ])
+      val str = PolyML.makestring message
+    in
+      print str;
+      Socket.sendVec (socket, message);
+      OK
+    end
+
+  fun parser (socket: Socket.active INetSock.stream_sock) =
+    let
+      val messageType = (* Byte.bytesToString ( *) Socket.recvVec (socket, 1)
+      val length = (* bytesToInt( *) Socket.recvVec (socket, 4)
+      val mP =
+        "Type: " ^ PolyML.makestring messageType ^ " -> "
+        ^ (Byte.bytesToString messageType)
+      val lP =
+        "Length: " ^ PolyML.makestring length ^ " -> "
+        ^ (Int.toString (bytesToInt length))
+    in
+      print "\n\n";
+      print mP;
+      print "\n\n";
+      print lP;
+      print "\n\n";
+      case (Byte.bytesToString messageType) of
+        "R" =>
+          ( print "Authenticating\n"
+          ; password (Socket.recvVec (socket, (bytesToInt length) - 4))
+          ; Posix.Process.sleep (Time.fromSeconds 1)
+          ; parser socket
+          )
+      | "Z" =>
+          ( print "ReadyForQuery\n"
+          ; Posix.Process.sleep (Time.fromSeconds 1)
+          ; print
+              ("Transaction status: "
+               ^ (Byte.bytesToString (Socket.recvVec (socket, 1))) ^ "\n")
+          )
+      | "E" =>
+          ( print
+              ("ERROR: "
+               ^
+               (Byte.bytesToString (Socket.recvVec
+                  (socket, (bytesToInt length) - 4))) ^ "\n")
+          ; Posix.Process.sleep (Time.fromSeconds 1)
+          ; parser socket
+          )
+      | "S" =>
+          ( print "Syncing...\n"
+          ; Socket.recvVec (socket, (bytesToInt length) - 4)
+          ; (* Posix.Process.sleep (Time.fromSeconds 1); *) parser socket
+          )
+      | "K" =>
+          ( print "BackendKeyData\n"
+          ; Socket.recvVec (socket, (bytesToInt length) - 4)
+          ; parser socket
+          )
+      | "T" =>
+          (let
+             val numberOfHeaders = bytesToInt16 (Socket.recvVec (socket, 2))
+             val contents = ref (Word8VectorSlice.full (Socket.recvVec
+               (socket, (bytesToInt length) - 4 - 2)))
+             val fieldName = ref ""
+           in
+             print ("Receiving " ^ Int.toString numberOfHeaders ^ " headers\n");
+             if numberOfHeaders <> 0 then
+               (case
+                  Word8VectorSlice.findi (fn (_, byte) => byte = 0wx0)
+                    (!contents)
+                of
+                  SOME (index, _) =>
+                    ( fieldName
+                      :=
+                      Byte.bytesToString (Word8VectorSlice.concat
+                        [Word8VectorSlice.subslice ((!contents), 0, SOME index)])
+                    ; print ("FIELD: " ^ (!fieldName) ^ "\n")
+                    )
+                | NONE => ())
+             else
+               print "Nothing :(\n"
+           end
+           handle SysErr => print "SYS\n")
+      | _ =>
+          ( print "Ignoring"
+          ; Socket.recvVec (socket, (bytesToInt length) - 4)
+          ; Posix.Process.sleep (Time.fromSeconds 1)
+          ; parser socket
+          )
+    end
 end

--- a/src/md5.sml
+++ b/src/md5.sml
@@ -3,147 +3,175 @@
  Code extracted from: https://raw.githubusercontent.com/MLton/mlton/master/benchmark/tests/md5.sml
  *)
 signature MD5 =
-  sig
-    type md5state
-(*    type slice = (Word8Vector.vector * int * int option) *)
-    val init : md5state
-    (* val updateSlice : (md5state * slice) -> md5state
-    *)
-    val update : (md5state * Word8Vector.vector) -> md5state
-    val final  : md5state -> Word8Vector.vector
-    val toHexString :  Word8Vector.vector -> string
-  end
+sig
+  type md5state
+  (*    type slice = (Word8Vector.vector * int * int option) *)
+  val init: md5state
+  (* val updateSlice : (md5state * slice) -> md5state
+  *)
+  val update: (md5state * Word8Vector.vector) -> md5state
+  val final: md5state -> Word8Vector.vector
+  val toHexString: Word8Vector.vector -> string
+end
 
 (* Quick and dirty transliteration of C code *)
 structure MD5 :> MD5 =
+struct
+  structure W32 = Word32
+  structure W8V =
   struct
-    structure W32 = Word32
-    structure W8V = 
-      struct
-        open Word8Vector
-        fun extract (vec, s, l) =
-           let
-              val n =
-                 case l of
-                    NONE => length vec - s
-                  | SOME i => i
-           in
-              tabulate (n, fn i => sub (vec, s + i))
-           end
+    open Word8Vector
+    fun extract (vec, s, l) =
+      let
+        val n =
+          case l of
+            NONE => length vec - s
+          | SOME i => i
+      in
+        tabulate (n, fn i => sub (vec, s + i))
       end
-    type word64  = {hi:W32.word,lo:W32.word}
-    type word128 = {A:W32.word, B:W32.word, C:W32.word,  D:W32.word}
-    type md5state = {digest:word128,
-                       mlen:word64, 
-                        buf:Word8Vector.vector}
+  end
+  type word64 = {hi: W32.word, lo: W32.word}
+  type word128 = {A: W32.word, B: W32.word, C: W32.word, D: W32.word}
+  type md5state = {digest: word128, mlen: word64, buf: Word8Vector.vector}
 
 
-
-    val w64_zero = ({hi=0w0,lo=0w0}:word64)
-    fun mul8add ({hi,lo},n) = let
-      val mul8lo = W32.<< (W32.fromInt (n),0w3)
-      val mul8hi = W32.>> (W32.fromInt (n),0w29)
-      val lo = W32.+ (lo,mul8lo)
-      val cout = if W32.< (lo,mul8lo) then 0w1 else 0w0
-      val hi = W32.+ (mul8hi,W32.+ (hi,cout))
-    in {hi=hi,lo=lo}
+  val w64_zero = ({hi = 0w0, lo = 0w0} : word64)
+  fun mul8add ({hi, lo}, n) =
+    let
+      val mul8lo = W32.<< (W32.fromInt (n), 0w3)
+      val mul8hi = W32.>> (W32.fromInt (n), 0w29)
+      val lo = W32.+ (lo, mul8lo)
+      val cout = if W32.< (lo, mul8lo) then 0w1 else 0w0
+      val hi = W32.+ (mul8hi, W32.+ (hi, cout))
+    in
+      {hi = hi, lo = lo}
     end
-  
-    fun packLittle wrds = let
+
+  fun packLittle wrds =
+    let
       fun loop [] = []
-        | loop (w::ws) = let
-            val b0 = Word8.fromLarge (W32.toLarge w)
-            val b1 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w8)))
-            val b2 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w16)))
-            val b3 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w24)))
-          in b0::b1::b2::b3:: (loop ws)
-          end
-    in W8V.fromList (loop wrds)
+        | loop (w :: ws) =
+            let
+              val b0 = Word8.fromLarge (W32.toLarge w)
+              val b1 = Word8.fromLarge (W32.toLarge (W32.>> (w, 0w8)))
+              val b2 = Word8.fromLarge (W32.toLarge (W32.>> (w, 0w16)))
+              val b3 = Word8.fromLarge (W32.toLarge (W32.>> (w, 0w24)))
+            in
+              b0 :: b1 :: b2 :: b3 :: (loop ws)
+            end
+    in
+      W8V.fromList (loop wrds)
     end
-    
-    val S11 = 0w7
-    val S12 = 0w12
-    val S13 = 0w17
-    val S14 = 0w22
-    val S21 = 0w5
-    val S22 = 0w9
-    val S23 = 0w14
-    val S24 = 0w20
-    val S31 = 0w4
-    val S32 = 0w11
-    val S33 = 0w16
-    val S34 = 0w23
-    val S41 = 0w6
-    val S42 = 0w10
-    val S43 = 0w15
-    val S44 = 0w21
-      
-    fun PADDING i =  W8V.tabulate (i,(fn 0 => 0wx80 | _ => 0wx0))
 
-    fun F (x,y,z) = W32.orb (W32.andb (x,y),
-                           W32.andb (W32.notb x,z))
-    fun G (x,y,z) = W32.orb (W32.andb (x,z),
-                           W32.andb (y,W32.notb z))
-    fun H (x,y,z) = W32.xorb (x,W32.xorb (y,z))
-    fun I (x,y,z) = W32.xorb (y,W32.orb (x,W32.notb z))
-    fun ROTATE_LEFT (x,n) =
-      W32.orb (W32.<< (x,n), W32.>> (x,0w32 - n))
+  val S11 = 0w7
+  val S12 = 0w12
+  val S13 = 0w17
+  val S14 = 0w22
+  val S21 = 0w5
+  val S22 = 0w9
+  val S23 = 0w14
+  val S24 = 0w20
+  val S31 = 0w4
+  val S32 = 0w11
+  val S33 = 0w16
+  val S34 = 0w23
+  val S41 = 0w6
+  val S42 = 0w10
+  val S43 = 0w15
+  val S44 = 0w21
 
-    fun XX f (a,b,c,d,x,s,ac) = let
-      val a = W32.+ (a,W32.+ (W32.+ (f (b,c,d),x),ac))
-      val a = ROTATE_LEFT (a,s)
-    in W32.+ (a,b)
+  fun PADDING i =
+    W8V.tabulate (i, (fn 0 => 0wx80 | _ => 0wx0))
+
+  fun F (x, y, z) =
+    W32.orb (W32.andb (x, y), W32.andb (W32.notb x, z))
+  fun G (x, y, z) =
+    W32.orb (W32.andb (x, z), W32.andb (y, W32.notb z))
+  fun H (x, y, z) =
+    W32.xorb (x, W32.xorb (y, z))
+  fun I (x, y, z) =
+    W32.xorb (y, W32.orb (x, W32.notb z))
+  fun ROTATE_LEFT (x, n) =
+    W32.orb (W32.<< (x, n), W32.>> (x, 0w32 - n))
+
+  fun XX f (a, b, c, d, x, s, ac) =
+    let
+      val a = W32.+ (a, W32.+ (W32.+ (f (b, c, d), x), ac))
+      val a = ROTATE_LEFT (a, s)
+    in
+      W32.+ (a, b)
     end
-                            
-    val FF = XX F
-    val GG = XX G
-    val HH = XX H
-    val II = XX I
 
-    val empty_buf = W8V.tabulate (0,(fn x => raise (Fail "buf")))
-    val init = {digest= {A=0wx67452301,
-                        B=0wxefcdab89,
-                        C=0wx98badcfe,
-                        D=0wx10325476},
-                mlen=w64_zero,
-                buf=empty_buf} : md5state
+  val FF = XX F
+  val GG = XX G
+  val HH = XX H
+  val II = XX I
 
-    fun update ({buf,digest,mlen}:md5state,input) = let
+  val empty_buf = W8V.tabulate (0, (fn x => raise (Fail "buf")))
+  val init =
+    { digest =
+        {A = 0wx67452301, B = 0wxefcdab89, C = 0wx98badcfe, D = 0wx10325476}
+    , mlen = w64_zero
+    , buf = empty_buf
+    } : md5state
+
+  fun update ({buf, digest, mlen}: md5state, input) =
+    let
       val inputLen = W8V.length input
       val needBytes = 64 - W8V.length buf
-      fun loop (i,digest) =
-        if i + 63 < inputLen then
-          loop (i + 64,transform (digest,i,input))
-        else (i,digest)
-      val (buf,(i,digest)) =
-        if inputLen >= needBytes then  let
-          val buf = W8V.concat [buf,W8V.extract (input,0,SOME needBytes)]
-          val digest = transform (digest,0,buf)
-        in (empty_buf,loop (needBytes,digest))
-        end
-        else (buf,(0,digest))
-      val buf = W8V.concat [buf, W8V.extract (input,i,SOME (inputLen-i))]
-      val mlen = mul8add (mlen,inputLen)
-    in {buf=buf,digest=digest,mlen=mlen}
+      fun loop (i, digest) =
+        if i + 63 < inputLen then loop (i + 64, transform (digest, i, input))
+        else (i, digest)
+      val (buf, (i, digest)) =
+        if inputLen >= needBytes then
+          let
+            val buf = W8V.concat [buf, W8V.extract (input, 0, SOME needBytes)]
+            val digest = transform (digest, 0, buf)
+          in
+            (empty_buf, loop (needBytes, digest))
+          end
+        else
+          (buf, (0, digest))
+      val buf = W8V.concat [buf, W8V.extract (input, i, SOME (inputLen - i))]
+      val mlen = mul8add (mlen, inputLen)
+    in
+      {buf = buf, digest = digest, mlen = mlen}
     end
-    and final (state:md5state) = let
-      val {mlen= {lo,hi},buf,...} = state
-      val bits = packLittle [lo,hi]
+  and final (state: md5state) =
+    let
+      val {mlen = {lo, hi}, buf, ...} = state
+      val bits = packLittle [lo, hi]
       val index = W8V.length buf
       val padLen = if index < 56 then 56 - index else 120 - index
-      val state = update (state,PADDING padLen)
-      val {digest= {A,B,C,D},...} = update (state,bits)
-    in packLittle [A,B,C,D]
+      val state = update (state, PADDING padLen)
+      val {digest = {A, B, C, D}, ...} = update (state, bits)
+    in
+      packLittle [A, B, C, D]
     end
-    and transform ({A,B,C,D},i,buf) = let
+  and transform ({A, B, C, D}, i, buf) =
+    let
       val off = i div PackWord32Little.bytesPerElem
-      fun x (n)  = Word32.fromLarge (PackWord32Little.subVec (buf,n + off))
-      val (a,b,c,d) = (A,B,C,D)
+      fun x (n) =
+        Word32.fromLarge (PackWord32Little.subVec (buf, n + off))
+      val (a, b, c, d) = (A, B, C, D)
       (* fetch to avoid range checks *)
-      val x_00 = x (0)  val x_01 = x (1)  val x_02 = x (2)  val x_03 = x (3)
-      val x_04 = x (4)  val x_05 = x (5)  val x_06 = x (6)  val x_07 = x (7)
-      val x_08 = x (8)  val x_09 = x (9)  val x_10 = x (10) val x_11 = x (11)
-      val x_12 = x (12) val x_13 = x (13) val x_14 = x (14) val x_15 = x (15)
+      val x_00 = x (0)
+      val x_01 = x (1)
+      val x_02 = x (2)
+      val x_03 = x (3)
+      val x_04 = x (4)
+      val x_05 = x (5)
+      val x_06 = x (6)
+      val x_07 = x (7)
+      val x_08 = x (8)
+      val x_09 = x (9)
+      val x_10 = x (10)
+      val x_11 = x (11)
+      val x_12 = x (12)
+      val x_13 = x (13)
+      val x_14 = x (14)
+      val x_15 = x (15)
 
       val a = FF (a, b, c, d, x_00, S11, 0wxd76aa478) (* 1 *)
       val d = FF (d, a, b, c, x_01, S12, 0wxe8c7b756) (* 2 *)
@@ -161,14 +189,14 @@ structure MD5 :> MD5 =
       val d = FF (d, a, b, c, x_13, S12, 0wxfd987193) (* 14 *)
       val c = FF (c, d, a, b, x_14, S13, 0wxa679438e) (* 15 *)
       val b = FF (b, c, d, a, x_15, S14, 0wx49b40821) (* 16 *)
-          
+
       (* Round 2 *)
       val a = GG (a, b, c, d, x_01, S21, 0wxf61e2562) (* 17 *)
       val d = GG (d, a, b, c, x_06, S22, 0wxc040b340) (* 18 *)
       val c = GG (c, d, a, b, x_11, S23, 0wx265e5a51) (* 19 *)
       val b = GG (b, c, d, a, x_00, S24, 0wxe9b6c7aa) (* 20 *)
       val a = GG (a, b, c, d, x_05, S21, 0wxd62f105d) (* 21 *)
-      val d = GG (d, a, b, c, x_10, S22,  0wx2441453) (* 22 *)
+      val d = GG (d, a, b, c, x_10, S22, 0wx2441453) (* 22 *)
       val c = GG (c, d, a, b, x_15, S23, 0wxd8a1e681) (* 23 *)
       val b = GG (b, c, d, a, x_04, S24, 0wxe7d3fbc8) (* 24 *)
       val a = GG (a, b, c, d, x_09, S21, 0wx21e1cde6) (* 25 *)
@@ -179,7 +207,7 @@ structure MD5 :> MD5 =
       val d = GG (d, a, b, c, x_02, S22, 0wxfcefa3f8) (* 30 *)
       val c = GG (c, d, a, b, x_07, S23, 0wx676f02d9) (* 31 *)
       val b = GG (b, c, d, a, x_12, S24, 0wx8d2a4c8a) (* 32 *)
-          
+
       (* Round 3 *)
       val a = HH (a, b, c, d, x_05, S31, 0wxfffa3942) (* 33 *)
       val d = HH (d, a, b, c, x_08, S32, 0wx8771f681) (* 34 *)
@@ -192,12 +220,12 @@ structure MD5 :> MD5 =
       val a = HH (a, b, c, d, x_13, S31, 0wx289b7ec6) (* 41 *)
       val d = HH (d, a, b, c, x_00, S32, 0wxeaa127fa) (* 42 *)
       val c = HH (c, d, a, b, x_03, S33, 0wxd4ef3085) (* 43 *)
-      val b = HH (b, c, d, a, x_06, S34,  0wx4881d05) (* 44 *)
+      val b = HH (b, c, d, a, x_06, S34, 0wx4881d05) (* 44 *)
       val a = HH (a, b, c, d, x_09, S31, 0wxd9d4d039) (* 45 *)
       val d = HH (d, a, b, c, x_12, S32, 0wxe6db99e5) (* 46 *)
       val c = HH (c, d, a, b, x_15, S33, 0wx1fa27cf8) (* 47 *)
       val b = HH (b, c, d, a, x_02, S34, 0wxc4ac5665) (* 48 *)
-          
+
       (* Round 4 *)
       val a = II (a, b, c, d, x_00, S41, 0wxf4292244) (* 49 *)
       val d = II (d, a, b, c, x_07, S42, 0wx432aff97) (* 50 *)
@@ -216,69 +244,76 @@ structure MD5 :> MD5 =
       val c = II (c, d, a, b, x_02, S43, 0wx2ad7d2bb) (* 63 *)
       val b = II (b, c, d, a, x_09, S44, 0wxeb86d391) (* 64 *)
 
-      val A = Word32.+ (A,a)
-      val B = Word32.+ (B,b)
-      val C = Word32.+ (C,c)
-      val D = Word32.+ (D,d)
-    in {A=A,B=B,C=C,D=D}
+      val A = Word32.+ (A, a)
+      val B = Word32.+ (B, b)
+      val C = Word32.+ (C, c)
+      val D = Word32.+ (D, d)
+    in
+      {A = A, B = B, C = C, D = D}
     end
 
-    val hxd = "0123456789abcdef"
-    fun toHexString v = let
-      fun byte2hex (b,acc) =
-        (String.sub (hxd,(Word8.toInt b) div 16))::
-        (String.sub (hxd,(Word8.toInt b) mod 16))::acc
+  val hxd = "0123456789abcdef"
+  fun toHexString v =
+    let
+      fun byte2hex (b, acc) =
+        (String.sub (hxd, (Word8.toInt b) div 16))
+        :: (String.sub (hxd, (Word8.toInt b) mod 16)) :: acc
       val digits = Word8Vector.foldr byte2hex [] v
-    in String.implode (digits)
+    in
+      String.implode (digits)
     end
-  end
+end
 
 structure Test =
-  struct
-    val tests =
-      [("", "d41d8cd98f00b204e9800998ecf8427e"),
-       ("a", "0cc175b9c0f1b6a831c399e269772661"),
-       ("abc", "900150983cd24fb0d6963f7d28e17f72"),
-       ("message digest", "f96b697d7cb7938d525a2f31aaf161d0"),
-       ("abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b"),
-       ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
-        "d174ab98d277d9f5a5611c2c9f419d9f"),
-       ("12345678901234567890123456789012345678901234567890123456789012345678901234567890",
-        "57edf4a22be3c955ac49da2e2107b67a")]
-   
-    fun do_tests () =  let
-      fun f (x,s) = let
-        val mstate = MD5.update (MD5.init,Byte.stringToBytes x)
-        val hash = MD5.final (mstate)
-      in print ("   input: "^x^"\n");
-        print ("expected: "^s^"\n");
-        print ("produced: "^MD5.toHexString (hash)^"\n")
-      end
-    in List.app f tests
+struct
+  val tests =
+    [ ("", "d41d8cd98f00b204e9800998ecf8427e")
+    , ("a", "0cc175b9c0f1b6a831c399e269772661")
+    , ("abc", "900150983cd24fb0d6963f7d28e17f72")
+    , ("message digest", "f96b697d7cb7938d525a2f31aaf161d0")
+    , ("abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b")
+    , ( "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+      , "d174ab98d277d9f5a5611c2c9f419d9f"
+      )
+    , ( "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+      , "57edf4a22be3c955ac49da2e2107b67a"
+      )
+    ]
+
+  fun do_tests () =
+    let
+      fun f (x, s) =
+        let
+          val mstate = MD5.update (MD5.init, Byte.stringToBytes x)
+          val hash = MD5.final (mstate)
+        in
+          print ("   input: " ^ x ^ "\n");
+          print ("expected: " ^ s ^ "\n");
+          print ("produced: " ^ MD5.toHexString (hash) ^ "\n")
+        end
+    in
+      List.app f tests
     end
-    val BLOCK_LEN = 10000
-    val BLOCK_COUNT = 100000
-    fun time_test () = let
-      val block = Word8Vector.tabulate (BLOCK_LEN,Word8.fromInt)
-      fun loop (n,s) =
-        if n < BLOCK_COUNT then
-          loop (n+1,MD5.update (s,block))
-        else s
-      val s = loop (0,MD5.init)
+  val BLOCK_LEN = 10000
+  val BLOCK_COUNT = 100000
+  fun time_test () =
+    let
+      val block = Word8Vector.tabulate (BLOCK_LEN, Word8.fromInt)
+      fun loop (n, s) =
+        if n < BLOCK_COUNT then loop (n + 1, MD5.update (s, block)) else s
+      val s = loop (0, MD5.init)
       val hash = MD5.final s
       val _ = print (concat [MD5.toHexString hash, "\n"])
     in
-       if MD5.toHexString hash <> "766a2bb5d24bddae466c572bcabca3ee"
-          then raise Fail "bug"
-          else ()
+      if MD5.toHexString hash <> "766a2bb5d24bddae466c572bcabca3ee" then
+        raise Fail "bug"
+      else
+        ()
     end
-  end
+end
 
 structure Main =
-   struct
-      fun doit n =
-         if n = 0
-            then ()
-         else (Test.time_test ()
-               ; doit (n - 1))
-   end
+struct
+  fun doit n =
+    if n = 0 then () else (Test.time_test (); doit (n - 1))
+end

--- a/src/md5.sml
+++ b/src/md5.sml
@@ -1,0 +1,284 @@
+(* Copyright (C) 2001 Daniel Wang. All rights reserved.
+ Derived from the RSA Data Security, Inc. MD5 Message-Digest Algorithm.
+ Code extracted from: https://raw.githubusercontent.com/MLton/mlton/master/benchmark/tests/md5.sml
+ *)
+signature MD5 =
+  sig
+    type md5state
+(*    type slice = (Word8Vector.vector * int * int option) *)
+    val init : md5state
+    (* val updateSlice : (md5state * slice) -> md5state
+    *)
+    val update : (md5state * Word8Vector.vector) -> md5state
+    val final  : md5state -> Word8Vector.vector
+    val toHexString :  Word8Vector.vector -> string
+  end
+
+(* Quick and dirty transliteration of C code *)
+structure MD5 :> MD5 =
+  struct
+    structure W32 = Word32
+    structure W8V = 
+      struct
+        open Word8Vector
+        fun extract (vec, s, l) =
+           let
+              val n =
+                 case l of
+                    NONE => length vec - s
+                  | SOME i => i
+           in
+              tabulate (n, fn i => sub (vec, s + i))
+           end
+      end
+    type word64  = {hi:W32.word,lo:W32.word}
+    type word128 = {A:W32.word, B:W32.word, C:W32.word,  D:W32.word}
+    type md5state = {digest:word128,
+                       mlen:word64, 
+                        buf:Word8Vector.vector}
+
+
+
+    val w64_zero = ({hi=0w0,lo=0w0}:word64)
+    fun mul8add ({hi,lo},n) = let
+      val mul8lo = W32.<< (W32.fromInt (n),0w3)
+      val mul8hi = W32.>> (W32.fromInt (n),0w29)
+      val lo = W32.+ (lo,mul8lo)
+      val cout = if W32.< (lo,mul8lo) then 0w1 else 0w0
+      val hi = W32.+ (mul8hi,W32.+ (hi,cout))
+    in {hi=hi,lo=lo}
+    end
+  
+    fun packLittle wrds = let
+      fun loop [] = []
+        | loop (w::ws) = let
+            val b0 = Word8.fromLarge (W32.toLarge w)
+            val b1 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w8)))
+            val b2 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w16)))
+            val b3 = Word8.fromLarge (W32.toLarge (W32.>> (w,0w24)))
+          in b0::b1::b2::b3:: (loop ws)
+          end
+    in W8V.fromList (loop wrds)
+    end
+    
+    val S11 = 0w7
+    val S12 = 0w12
+    val S13 = 0w17
+    val S14 = 0w22
+    val S21 = 0w5
+    val S22 = 0w9
+    val S23 = 0w14
+    val S24 = 0w20
+    val S31 = 0w4
+    val S32 = 0w11
+    val S33 = 0w16
+    val S34 = 0w23
+    val S41 = 0w6
+    val S42 = 0w10
+    val S43 = 0w15
+    val S44 = 0w21
+      
+    fun PADDING i =  W8V.tabulate (i,(fn 0 => 0wx80 | _ => 0wx0))
+
+    fun F (x,y,z) = W32.orb (W32.andb (x,y),
+                           W32.andb (W32.notb x,z))
+    fun G (x,y,z) = W32.orb (W32.andb (x,z),
+                           W32.andb (y,W32.notb z))
+    fun H (x,y,z) = W32.xorb (x,W32.xorb (y,z))
+    fun I (x,y,z) = W32.xorb (y,W32.orb (x,W32.notb z))
+    fun ROTATE_LEFT (x,n) =
+      W32.orb (W32.<< (x,n), W32.>> (x,0w32 - n))
+
+    fun XX f (a,b,c,d,x,s,ac) = let
+      val a = W32.+ (a,W32.+ (W32.+ (f (b,c,d),x),ac))
+      val a = ROTATE_LEFT (a,s)
+    in W32.+ (a,b)
+    end
+                            
+    val FF = XX F
+    val GG = XX G
+    val HH = XX H
+    val II = XX I
+
+    val empty_buf = W8V.tabulate (0,(fn x => raise (Fail "buf")))
+    val init = {digest= {A=0wx67452301,
+                        B=0wxefcdab89,
+                        C=0wx98badcfe,
+                        D=0wx10325476},
+                mlen=w64_zero,
+                buf=empty_buf} : md5state
+
+    fun update ({buf,digest,mlen}:md5state,input) = let
+      val inputLen = W8V.length input
+      val needBytes = 64 - W8V.length buf
+      fun loop (i,digest) =
+        if i + 63 < inputLen then
+          loop (i + 64,transform (digest,i,input))
+        else (i,digest)
+      val (buf,(i,digest)) =
+        if inputLen >= needBytes then  let
+          val buf = W8V.concat [buf,W8V.extract (input,0,SOME needBytes)]
+          val digest = transform (digest,0,buf)
+        in (empty_buf,loop (needBytes,digest))
+        end
+        else (buf,(0,digest))
+      val buf = W8V.concat [buf, W8V.extract (input,i,SOME (inputLen-i))]
+      val mlen = mul8add (mlen,inputLen)
+    in {buf=buf,digest=digest,mlen=mlen}
+    end
+    and final (state:md5state) = let
+      val {mlen= {lo,hi},buf,...} = state
+      val bits = packLittle [lo,hi]
+      val index = W8V.length buf
+      val padLen = if index < 56 then 56 - index else 120 - index
+      val state = update (state,PADDING padLen)
+      val {digest= {A,B,C,D},...} = update (state,bits)
+    in packLittle [A,B,C,D]
+    end
+    and transform ({A,B,C,D},i,buf) = let
+      val off = i div PackWord32Little.bytesPerElem
+      fun x (n)  = Word32.fromLarge (PackWord32Little.subVec (buf,n + off))
+      val (a,b,c,d) = (A,B,C,D)
+      (* fetch to avoid range checks *)
+      val x_00 = x (0)  val x_01 = x (1)  val x_02 = x (2)  val x_03 = x (3)
+      val x_04 = x (4)  val x_05 = x (5)  val x_06 = x (6)  val x_07 = x (7)
+      val x_08 = x (8)  val x_09 = x (9)  val x_10 = x (10) val x_11 = x (11)
+      val x_12 = x (12) val x_13 = x (13) val x_14 = x (14) val x_15 = x (15)
+
+      val a = FF (a, b, c, d, x_00, S11, 0wxd76aa478) (* 1 *)
+      val d = FF (d, a, b, c, x_01, S12, 0wxe8c7b756) (* 2 *)
+      val c = FF (c, d, a, b, x_02, S13, 0wx242070db) (* 3 *)
+      val b = FF (b, c, d, a, x_03, S14, 0wxc1bdceee) (* 4 *)
+      val a = FF (a, b, c, d, x_04, S11, 0wxf57c0faf) (* 5 *)
+      val d = FF (d, a, b, c, x_05, S12, 0wx4787c62a) (* 6 *)
+      val c = FF (c, d, a, b, x_06, S13, 0wxa8304613) (* 7 *)
+      val b = FF (b, c, d, a, x_07, S14, 0wxfd469501) (* 8 *)
+      val a = FF (a, b, c, d, x_08, S11, 0wx698098d8) (* 9 *)
+      val d = FF (d, a, b, c, x_09, S12, 0wx8b44f7af) (* 10 *)
+      val c = FF (c, d, a, b, x_10, S13, 0wxffff5bb1) (* 11 *)
+      val b = FF (b, c, d, a, x_11, S14, 0wx895cd7be) (* 12 *)
+      val a = FF (a, b, c, d, x_12, S11, 0wx6b901122) (* 13 *)
+      val d = FF (d, a, b, c, x_13, S12, 0wxfd987193) (* 14 *)
+      val c = FF (c, d, a, b, x_14, S13, 0wxa679438e) (* 15 *)
+      val b = FF (b, c, d, a, x_15, S14, 0wx49b40821) (* 16 *)
+          
+      (* Round 2 *)
+      val a = GG (a, b, c, d, x_01, S21, 0wxf61e2562) (* 17 *)
+      val d = GG (d, a, b, c, x_06, S22, 0wxc040b340) (* 18 *)
+      val c = GG (c, d, a, b, x_11, S23, 0wx265e5a51) (* 19 *)
+      val b = GG (b, c, d, a, x_00, S24, 0wxe9b6c7aa) (* 20 *)
+      val a = GG (a, b, c, d, x_05, S21, 0wxd62f105d) (* 21 *)
+      val d = GG (d, a, b, c, x_10, S22,  0wx2441453) (* 22 *)
+      val c = GG (c, d, a, b, x_15, S23, 0wxd8a1e681) (* 23 *)
+      val b = GG (b, c, d, a, x_04, S24, 0wxe7d3fbc8) (* 24 *)
+      val a = GG (a, b, c, d, x_09, S21, 0wx21e1cde6) (* 25 *)
+      val d = GG (d, a, b, c, x_14, S22, 0wxc33707d6) (* 26 *)
+      val c = GG (c, d, a, b, x_03, S23, 0wxf4d50d87) (* 27 *)
+      val b = GG (b, c, d, a, x_08, S24, 0wx455a14ed) (* 28 *)
+      val a = GG (a, b, c, d, x_13, S21, 0wxa9e3e905) (* 29 *)
+      val d = GG (d, a, b, c, x_02, S22, 0wxfcefa3f8) (* 30 *)
+      val c = GG (c, d, a, b, x_07, S23, 0wx676f02d9) (* 31 *)
+      val b = GG (b, c, d, a, x_12, S24, 0wx8d2a4c8a) (* 32 *)
+          
+      (* Round 3 *)
+      val a = HH (a, b, c, d, x_05, S31, 0wxfffa3942) (* 33 *)
+      val d = HH (d, a, b, c, x_08, S32, 0wx8771f681) (* 34 *)
+      val c = HH (c, d, a, b, x_11, S33, 0wx6d9d6122) (* 35 *)
+      val b = HH (b, c, d, a, x_14, S34, 0wxfde5380c) (* 36 *)
+      val a = HH (a, b, c, d, x_01, S31, 0wxa4beea44) (* 37 *)
+      val d = HH (d, a, b, c, x_04, S32, 0wx4bdecfa9) (* 38 *)
+      val c = HH (c, d, a, b, x_07, S33, 0wxf6bb4b60) (* 39 *)
+      val b = HH (b, c, d, a, x_10, S34, 0wxbebfbc70) (* 40 *)
+      val a = HH (a, b, c, d, x_13, S31, 0wx289b7ec6) (* 41 *)
+      val d = HH (d, a, b, c, x_00, S32, 0wxeaa127fa) (* 42 *)
+      val c = HH (c, d, a, b, x_03, S33, 0wxd4ef3085) (* 43 *)
+      val b = HH (b, c, d, a, x_06, S34,  0wx4881d05) (* 44 *)
+      val a = HH (a, b, c, d, x_09, S31, 0wxd9d4d039) (* 45 *)
+      val d = HH (d, a, b, c, x_12, S32, 0wxe6db99e5) (* 46 *)
+      val c = HH (c, d, a, b, x_15, S33, 0wx1fa27cf8) (* 47 *)
+      val b = HH (b, c, d, a, x_02, S34, 0wxc4ac5665) (* 48 *)
+          
+      (* Round 4 *)
+      val a = II (a, b, c, d, x_00, S41, 0wxf4292244) (* 49 *)
+      val d = II (d, a, b, c, x_07, S42, 0wx432aff97) (* 50 *)
+      val c = II (c, d, a, b, x_14, S43, 0wxab9423a7) (* 51 *)
+      val b = II (b, c, d, a, x_05, S44, 0wxfc93a039) (* 52 *)
+      val a = II (a, b, c, d, x_12, S41, 0wx655b59c3) (* 53 *)
+      val d = II (d, a, b, c, x_03, S42, 0wx8f0ccc92) (* 54 *)
+      val c = II (c, d, a, b, x_10, S43, 0wxffeff47d) (* 55 *)
+      val b = II (b, c, d, a, x_01, S44, 0wx85845dd1) (* 56 *)
+      val a = II (a, b, c, d, x_08, S41, 0wx6fa87e4f) (* 57 *)
+      val d = II (d, a, b, c, x_15, S42, 0wxfe2ce6e0) (* 58 *)
+      val c = II (c, d, a, b, x_06, S43, 0wxa3014314) (* 59 *)
+      val b = II (b, c, d, a, x_13, S44, 0wx4e0811a1) (* 60 *)
+      val a = II (a, b, c, d, x_04, S41, 0wxf7537e82) (* 61 *)
+      val d = II (d, a, b, c, x_11, S42, 0wxbd3af235) (* 62 *)
+      val c = II (c, d, a, b, x_02, S43, 0wx2ad7d2bb) (* 63 *)
+      val b = II (b, c, d, a, x_09, S44, 0wxeb86d391) (* 64 *)
+
+      val A = Word32.+ (A,a)
+      val B = Word32.+ (B,b)
+      val C = Word32.+ (C,c)
+      val D = Word32.+ (D,d)
+    in {A=A,B=B,C=C,D=D}
+    end
+
+    val hxd = "0123456789abcdef"
+    fun toHexString v = let
+      fun byte2hex (b,acc) =
+        (String.sub (hxd,(Word8.toInt b) div 16))::
+        (String.sub (hxd,(Word8.toInt b) mod 16))::acc
+      val digits = Word8Vector.foldr byte2hex [] v
+    in String.implode (digits)
+    end
+  end
+
+structure Test =
+  struct
+    val tests =
+      [("", "d41d8cd98f00b204e9800998ecf8427e"),
+       ("a", "0cc175b9c0f1b6a831c399e269772661"),
+       ("abc", "900150983cd24fb0d6963f7d28e17f72"),
+       ("message digest", "f96b697d7cb7938d525a2f31aaf161d0"),
+       ("abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b"),
+       ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+        "d174ab98d277d9f5a5611c2c9f419d9f"),
+       ("12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+        "57edf4a22be3c955ac49da2e2107b67a")]
+   
+    fun do_tests () =  let
+      fun f (x,s) = let
+        val mstate = MD5.update (MD5.init,Byte.stringToBytes x)
+        val hash = MD5.final (mstate)
+      in print ("   input: "^x^"\n");
+        print ("expected: "^s^"\n");
+        print ("produced: "^MD5.toHexString (hash)^"\n")
+      end
+    in List.app f tests
+    end
+    val BLOCK_LEN = 10000
+    val BLOCK_COUNT = 100000
+    fun time_test () = let
+      val block = Word8Vector.tabulate (BLOCK_LEN,Word8.fromInt)
+      fun loop (n,s) =
+        if n < BLOCK_COUNT then
+          loop (n+1,MD5.update (s,block))
+        else s
+      val s = loop (0,MD5.init)
+      val hash = MD5.final s
+      val _ = print (concat [MD5.toHexString hash, "\n"])
+    in
+       if MD5.toHexString hash <> "766a2bb5d24bddae466c572bcabca3ee"
+          then raise Fail "bug"
+          else ()
+    end
+  end
+
+structure Main =
+   struct
+      fun doit n =
+         if n = 0
+            then ()
+         else (Test.time_test ()
+               ; doit (n - 1))
+   end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -3,10 +3,12 @@ fun main _ =
     val socket = PostgresClient.connect ()
   in
     PostgresClient.startup socket;
-    PostgresClient.parser socket [];
-    PostgresClient.execute socket
-      "SELECT 'Hello' AS First, 'World! :)' AS Second;";
-    PostgresClient.parser socket [];
-    PostgresClient.parser socket [];
+    PostgresClient.parser socket;
+    PostgresClient.execute socket "SELECT NULL AS First, 'World! :)' AS Second;";
+    PostgresClient.parser socket;
+    PostgresClient.display ();
+    PostgresClient.execute socket "SELECT 'See ya!' AS First, ':)' AS Second;";
+    PostgresClient.parser socket;
+    PostgresClient.display ();
     Socket.close socket
   end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -4,7 +4,8 @@ fun main _ =
   in
     PostgresClient.startup socket;
     PostgresClient.parser socket [];
-    PostgresClient.execute socket "SELECT 'Hello :)' AS Message";
+    PostgresClient.execute socket
+      "SELECT 'Hello' AS First, 'World! :)' AS Second;";
     PostgresClient.parser socket [];
     PostgresClient.parser socket [];
     Socket.close socket

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -1,10 +1,10 @@
 fun main _ =
-    let 
-      val socket = PostgresClient.connect()
-    in
-      PostgresClient.startup socket;
-      PostgresClient.parser socket;
-      PostgresClient.parser socket;
-      (* Posix.Process.sleep  (Time.fromSeconds 3); *)
-      Socket.close socket
-    end
+  let
+    val socket = PostgresClient.connect ()
+  in
+    PostgresClient.startup socket;
+    PostgresClient.parser socket;
+    PostgresClient.execute socket "SELECT 'Hello :)' AS Message";
+    PostgresClient.parser socket;
+    Socket.close socket
+  end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -3,5 +3,8 @@ fun main _ =
       val socket = PostgresClient.connect()
     in
       PostgresClient.startup socket;
-      PostgresClient.parser socket
+      PostgresClient.parser socket;
+      PostgresClient.parser socket;
+      (* Posix.Process.sleep  (Time.fromSeconds 3); *)
+      Socket.close socket
     end

--- a/tests/main.sml
+++ b/tests/main.sml
@@ -3,8 +3,9 @@ fun main _ =
     val socket = PostgresClient.connect ()
   in
     PostgresClient.startup socket;
-    PostgresClient.parser socket;
+    PostgresClient.parser socket [];
     PostgresClient.execute socket "SELECT 'Hello :)' AS Message";
-    PostgresClient.parser socket;
+    PostgresClient.parser socket [];
+    PostgresClient.parser socket [];
     Socket.close socket
   end


### PR DESCRIPTION
### Context
On the postgres protocol, several messages ought to be handled by the driver when performing queries (`Q`) and fetching results (`T` and `D`).

### Scope

Here I implement:
- Handlers for `T`, `D`, `Q`, `S` and `Z` from [protocol message formats](https://www.postgresql.org/docs/current/protocol-message-formats.html) exposed by postgres;
- Adds a preliminary layer of abstraction on a generic driver for future drivers as functors.

### How to test
- To start postgres:
  - nix develop --impure
  - devenv up 
- To compile and run:
  - nix run .#execute -L --impure

### Notes
- Bugs:
  - https://github.com/PerplexSystems/smlpg/issues/3

![image](https://github.com/PerplexSystems/smlpg/assets/14153897/e80ef2ff-8daa-4678-b618-28d668b2bc2a)
